### PR TITLE
Add option to create a cross-dependency file

### DIFF
--- a/index.js
+++ b/index.js
@@ -121,7 +121,7 @@ function normalizeOptions(b, opts) {
   if (opts.url && opts.url.slice(-1) != '/') {
     opts.url += '/';
   }
-  opts.crossDependencyFile = opts.crossDependencyFile || false;
+  opts.crossDependencyFile = opts.crossDependencyFile || opts['cross-dependency-file'] || false;
 
   var mapFile = opts.map;
   var mapIsFile = (typeof mapFile == 'string');


### PR DESCRIPTION
Adds a CLI arg which allows the user to supply a filename to write JSON documenting the cross-dependencies of the partitions. This is useful for investigating specifically what causes one partition's reliance on another partition in order to finish loading. Example output:

```
{
    "post-core.js": {},
    "needs-nothing.js": {
        "core.js": [
            "./src/message/channel.js"
        ],
        "post-core.js": [
            "./src/core/nothing.js"
        ]
    },
    "core.js": {}
}
```

where `needs-nothing.js` contains a module that requires `core/nothing.js`, which has been compiled into the `post-core.js` partition. `core.js` and `post-core.js` are partitions that don't require anything that's defined in any other partitions, so their cross-dependency lists are empty.

I'm totally unfamiliar with browserify plugin development flow; I've sorta just guessed where this code should go. Let me know if you'd like any tweaks made.
