### PR TITLE
Add ability to set partition load status from partition file

### DIFF
--- a/index.js
+++ b/index.js
@@ -293,6 +293,8 @@ function wrap(opts) {
 
     }
 
+    stream.push(new Buffer('\nloadjs.fileLoaded("' + file + '");'));
+
     first = false;
     next();
   }

--- a/index.js
+++ b/index.js
@@ -275,6 +275,10 @@ function wrap(opts) {
     stream.push(wrappedSource);
     lineno += newlinesIn(wrappedSource);
 
+    if (first) {
+        stream.push(new Buffer('\nloadjs.fileLoaded("' + row.destFile + '");'));
+    }
+
     if (first && opts.prelude) {
 
       if (opts.url) {
@@ -292,8 +296,6 @@ function wrap(opts) {
       ].join('')));
 
     }
-
-    stream.push(new Buffer('\nloadjs.fileLoaded("' + file + '");'));
 
     first = false;
     next();

--- a/preludes/_prelude.js
+++ b/preludes/_prelude.js
@@ -50,12 +50,18 @@ function noop() {
 var loading = {};
 var loaded = [];
 
+function fileLoaded(file) {
+  if (indexOf(loaded, file) == -1) {
+    loaded.push(file);
+  }
+}
+
 function loadScriptFile(file) {
   loadScript(loadjs.url + file, function(err) {
     var cbs = loading[file];
     if (!err) {
       loading[file] = null;
-      loaded.push(file);
+      fileLoaded(file);
     }
     fold(cbs, 0, function(cb) {
       cb(err, file);
@@ -116,6 +122,7 @@ var loadjs = global.loadjs = function(deps, fn, errFn) {
 };
 
 loadjs.d = __define;
+loadjs.fileLoaded = fileLoaded;
 
 loadjs.url = opts.url || '';
 loadjs.files = [];

--- a/preludes/prelude.js
+++ b/preludes/prelude.js
@@ -174,12 +174,18 @@ function noop() {
 var loading = {};
 var loaded = [];
 
+function fileLoaded(file) {
+  if (indexOf(loaded, file) == -1) {
+    loaded.push(file);
+  }
+}
+
 function loadScriptFile(file) {
   loadScript(loadjs.url + file, function(err) {
     var cbs = loading[file];
     if (!err) {
       loading[file] = null;
-      loaded.push(file);
+      fileLoaded(file);
     }
     fold(cbs, 0, function(cb) {
       cb(err, file);
@@ -240,6 +246,7 @@ var loadjs = global.loadjs = function(deps, fn, errFn) {
 };
 
 loadjs.d = __define;
+loadjs.fileLoaded = fileLoaded;
 
 loadjs.url = opts.url || '';
 loadjs.files = [];


### PR DESCRIPTION
Add ability to set partition load status from partition file. Resolves #6.

This is one possible solution to the problem that an inlined partition file, although fully registered and ready to be used, does not communicate its status to the `loadjs` function. This PR attaches a `loadjs.fileLoaded` method which a partition file calls once it finishes downloading (or when it runs inline straight out of the HTML) so loadjs knows to not download the code again.

I'd be happy to implement a more robust solution if there's a better way available.
