### PR TITLE
Could load module by exposed name

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,17 @@ The first row is the entry file. This file is the file you need to add to your
 page with a `<script src="entry.js"></script>`. This also includes necessary
 boilerplate to load the other files.
 
+### Use exposed name
+
+The module could be defined in format `file_path:expose_name` and be loaded by `loadjs(['expose_name'])`.
+
+```
+{
+  "entry.js": ["./a"],
+  "common.js": ["./b:common"]
+}
+```
+
 Loading modules
 ---------------
 
@@ -69,4 +80,3 @@ It can factor-out common modules in to different output files, but then you
 need to manually load the files with `<script>` tags. **partition-budle** can
 load the excluded modules later using the `loadjs` function and by simply using
 the module ID, rather than the final JS filename.
-

--- a/index.js
+++ b/index.js
@@ -30,8 +30,9 @@ function partitionBundle(b, opts) {
   // require the modules from the map
   forOwn(opts.map, function(modules, file) {
     modules.forEach(function(mod, i) {
-      var id = bresolve.sync(mod, rOpts);
-      shortIDLabels[id] = mod;
+      var parsed = parseModuleIdLabel(mod);
+      var id = bresolve.sync(parsed.mod, rOpts);
+      shortIDLabels[id] = parsed.shortIdLabel;
       modules[i] = id;
       b.require(id, {entry: true});
     });
@@ -45,7 +46,14 @@ function partitionBundle(b, opts) {
 
   // install initial pipeline
   installBundlePipeline(b.pipeline, opts);
+}
 
+function parseModuleIdLabel(moduleName) {
+  var splited = moduleName.split(':');
+  return {
+    mod: splited[0],
+    shortIdLabel: splited[1] || splited[0]
+  };
 }
 
 function installBundlePipeline(pipeline, opts) {


### PR DESCRIPTION
Add new format `file_path:expose_name` to expose module name in configuration file.

if you defined as below

```
{
  "entry.js": ["./a.js"],
  "common.js": ["./b.js:common"]
}
```

`loadjs['common']` could be used to load module `./b.js`
